### PR TITLE
chore: 

### DIFF
--- a/app/src/__tests__/oauth2client.test.ts
+++ b/app/src/__tests__/oauth2client.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { GmailOAuthClient } from '@/lib/index.js'
+
+describe('Google OAuth2 Client class test', () => {
+  it('should generate an access token', async () => {
+    const oauthClient = new GmailOAuthClient()
+    const token = await oauthClient.getAccessToken()
+
+    expect(token).toHaveProperty('token')
+    expect(token).toHaveProperty('res')
+  })
+
+  it('should generate and store a new access token', async () => {
+    const oauthClient = new GmailOAuthClient()
+    await oauthClient.generateAccessToken()
+
+    expect(oauthClient.accessToken).toHaveProperty('token')
+    expect(oauthClient.accessToken).toHaveProperty('res')
+  })
+})

--- a/app/src/__tests__/send.test.ts
+++ b/app/src/__tests__/send.test.ts
@@ -1,15 +1,33 @@
 import { describe, expect, test } from 'vitest'
 import { send } from '@/lib/index.js'
+import { GmailOAuthClient } from '@/lib/index.js'
 
 const MAX_TIMEOUT = 10000
 const TEST_RECIPIENT = 'tester@gmail.com'
 
 describe('Send email test', () => {
-  test('Send a raw text email', async () => {
+  test('Send a text email', async () => {
+    // Sending email this way auto-generates a fresh access token
     await expect(send({
       recipient: TEST_RECIPIENT,
       subject: 'Test Simple Message',
       content: 'Henlo!'
     })).resolves.toBeUndefined()
+  }, MAX_TIMEOUT)
+
+  test('Send a text email using pre-generated OAuth2 access token', async () => {
+    const oauthClient = new GmailOAuthClient()
+    await oauthClient.generateAccessToken()
+
+    // Sending email this way does not regenerate an access token
+    await expect(
+      send(
+        {
+          recipient: TEST_RECIPIENT,
+          subject: 'Test Simple Message',
+          content: 'Henlo!'
+        }, oauthClient
+      )
+    ).resolves.toBeUndefined()
   }, MAX_TIMEOUT)
 })

--- a/app/src/__tests__/sendFormat.test.ts
+++ b/app/src/__tests__/sendFormat.test.ts
@@ -1,53 +1,82 @@
-import { describe, expect, it } from 'vitest'
-import { send } from '@/lib/index.js'
-import { EmailSchemaMessages } from '@/types/email.schema.js'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { GmailOAuthClient, send } from '@/lib/index.js'
 import { createLongString } from '@/utils/helpers.js'
+
+import { EmailSchemaMessages } from '@/types/email.schema.js'
 
 const MAX_TIMEOUT = 10000
 const TEST_RECIPIENT = 'tester@gmail.com'
 const TEST_SUBJECT = 'Test Simple Message'
 
 describe('Email format test', () => {
+  const oauthClient = new GmailOAuthClient()
+
+  // Generates an access token to use for the succeeding tests
+  beforeAll(async () => {
+    await oauthClient.generateAccessToken()
+  })
+
   // Testing invalid format emails
   it('should detect an invalid email format', async () => {
     const invalidEmail = 'tester!#5@.4/'
 
-    await expect(send({
-      recipient: invalidEmail,
-      subject: TEST_SUBJECT,
-      content: 'Henlo!'
-    })).rejects.toThrow(EmailSchemaMessages.RECIPIENT_EMAIL)
+    await expect(
+      send(
+        {
+          recipient: invalidEmail,
+          subject: TEST_SUBJECT,
+          content: 'Henlo!'
+        },
+        oauthClient
+      )
+    ).rejects.toThrow(EmailSchemaMessages.RECIPIENT_EMAIL)
   }, MAX_TIMEOUT)
 
   // Testing long email addresses
   it('should detect emails longer than 150 characters', async () => {
     const longRecipientEmail = createLongString(150) + '@gmail.com'
 
-    await expect(send({
-      recipient: longRecipientEmail,
-      subject: TEST_SUBJECT,
-      content: 'Henlo!'
-    })).rejects.toThrow(EmailSchemaMessages.RECIPIENT_EMAIL_LENGTH)
+    await expect(
+      send(
+        {
+          recipient: longRecipientEmail,
+          subject: TEST_SUBJECT,
+          content: 'Henlo!'
+        },
+        oauthClient
+      )
+    ).rejects.toThrow(EmailSchemaMessages.RECIPIENT_EMAIL_LENGTH)
   }, MAX_TIMEOUT)
 
   // Testing long subject/title content
   it('should detect long subject/title content', async () => {
     const longTitle = createLongString(201)
 
-    await expect(send({
-      recipient: TEST_RECIPIENT,
-      subject: longTitle,
-      content: 'Henlo!'
-    })).rejects.toThrow(EmailSchemaMessages.SUBJECT)
+    await expect(
+      send(
+        {
+          recipient: TEST_RECIPIENT,
+          subject: longTitle,
+          content: 'Henlo!'
+        },
+        oauthClient
+      )
+    ).rejects.toThrow(EmailSchemaMessages.SUBJECT)
   }, MAX_TIMEOUT)
 
   it('should detect long email message content', async () => {
     const longContent = createLongString(1501)
 
-    await expect(send({
-      recipient: TEST_RECIPIENT,
-      subject: TEST_SUBJECT,
-      content: longContent
-    })).rejects.toThrow(EmailSchemaMessages.CONTENT)
+    await expect(
+      send(
+        {
+          recipient: TEST_RECIPIENT,
+          subject: TEST_SUBJECT,
+          content: longContent
+        },
+        oauthClient
+      )
+    ).rejects.toThrow(EmailSchemaMessages.CONTENT)
   }, MAX_TIMEOUT)
 })

--- a/app/src/lib/email/send.ts
+++ b/app/src/lib/email/send.ts
@@ -8,8 +8,8 @@ import type { EmailType } from '@/types/email.schema.js'
  *  Sends a raw, text-content email to a recipient
  * @param {EmailType} params Email sending input parameters
  */
-export const send = async (params: EmailType): Promise<void> => {
-  const oauthClient = new GmailOAuthClient()
+export const send = async (params: EmailType, client?: GmailOAuthClient): Promise<void> => {
+  const oauthClient = client || new GmailOAuthClient()
 
   const handler = new EmailSender({
     host: TRANSPORT_SMTP_HOSTS.GMAIL,
@@ -18,7 +18,6 @@ export const send = async (params: EmailType): Promise<void> => {
 
   try {
     await handler.createTransport3LO(oauthClient)
-    console.log('Transport created')
   } catch (err: unknown) {
     if (err instanceof Error) {
       throw new Error(err.message)

--- a/app/src/lib/email/transport.ts
+++ b/app/src/lib/email/transport.ts
@@ -31,8 +31,12 @@ class EmailTransport implements IEmailTransport {
 
   async createTransport3LO (oauth2Client: GmailOAuthClient): Promise<void> {
     try {
-      // Retrieve a fresh access token
-      const token = await oauth2Client.getAccessToken()
+      let token = oauth2Client.accessToken
+
+      // Generate and retrieve a fresh access token
+      if (!token) {
+        token = await oauth2Client.getAccessToken() as string
+      }
 
       // Initialize the nodemailer transport with a fresh access token
       this.#transporter = nodemailer.createTransport(<SMTPTransport.Options>{

--- a/app/src/lib/email/transport.ts
+++ b/app/src/lib/email/transport.ts
@@ -35,7 +35,7 @@ class EmailTransport implements IEmailTransport {
 
       // Generate and retrieve a fresh access token
       if (!token) {
-        token = await oauth2Client.getAccessToken() as string
+        token = await oauth2Client.getAccessToken()
       }
 
       // Initialize the nodemailer transport with a fresh access token

--- a/app/src/lib/google/oauth2client.ts
+++ b/app/src/lib/google/oauth2client.ts
@@ -23,6 +23,9 @@ class GmailOAuthClient implements IGmailOAuthClient {
   /** Google OAuth2 refresh token from the Google OAuth2 Playground  */
   #refreshToken: string | null = null
 
+  /** Google OAuth2 access token generated using the #refreshToken */
+  #accessToken: string | null = null
+
   /**
    * @constructor
    * @param {Partial<IOauthClient>} params (Optional) constructor parameters. The corresponding `.env` variables
@@ -74,11 +77,19 @@ class GmailOAuthClient implements IGmailOAuthClient {
   }
 
   async getAccessToken (): Promise<GetAccessTokenResponse> {
+    this.checkClient()
+    return await this.#client!.getAccessToken()
+  }
+
+  async generateAccessToken (): Promise<void> {
+    this.checkClient()
+    this.#accessToken = await this.getAccessToken() as string
+  }
+
+  checkClient (): void {
     if (!this.#client) {
       throw new Error('Undefined OAuth2 client')
     }
-
-    return await this.#client?.getAccessToken()
   }
 
   get client (): OAuth2Client | null {
@@ -91,6 +102,10 @@ class GmailOAuthClient implements IGmailOAuthClient {
 
   get refreshToken (): string | null {
     return this.#refreshToken
+  }
+
+  get accessToken (): string | null {
+    return this.#accessToken
   }
 }
 

--- a/app/src/lib/google/oauth2client.ts
+++ b/app/src/lib/google/oauth2client.ts
@@ -24,7 +24,7 @@ class GmailOAuthClient implements IGmailOAuthClient {
   #refreshToken: string | null = null
 
   /** Google OAuth2 access token generated using the #refreshToken */
-  #accessToken: string | null = null
+  #accessToken: GetAccessTokenResponse | null = null
 
   /**
    * @constructor
@@ -83,7 +83,7 @@ class GmailOAuthClient implements IGmailOAuthClient {
 
   async generateAccessToken (): Promise<void> {
     this.checkClient()
-    this.#accessToken = await this.getAccessToken() as string
+    this.#accessToken = await this.getAccessToken()
   }
 
   checkClient (): void {
@@ -104,7 +104,7 @@ class GmailOAuthClient implements IGmailOAuthClient {
     return this.#refreshToken
   }
 
-  get accessToken (): string | null {
+  get accessToken (): GetAccessTokenResponse | null {
     return this.#accessToken
   }
 }

--- a/app/src/lib/google/oauth2client.ts
+++ b/app/src/lib/google/oauth2client.ts
@@ -92,6 +92,10 @@ class GmailOAuthClient implements IGmailOAuthClient {
     }
   }
 
+  set accessToken (accessToken: GetAccessTokenResponse | null) {
+    this.#accessToken = accessToken
+  }
+
   get client (): OAuth2Client | null {
     return this.#client
   }

--- a/app/src/types/oauth2client.interface.ts
+++ b/app/src/types/oauth2client.interface.ts
@@ -25,6 +25,18 @@ export interface IGmailOAuthClient {
   getAccessToken (): Promise<GetAccessTokenResponse>;
 
   /**
+   * Generates a Google OAuth2 access token, storing it in the local `this.#accessToken`
+   * @returns {Promise<void>}
+   */
+  generateAccessToken (): Promise<void>;
+
+  /**
+   * Validates that the OAuth2 client is initialized
+   * @throws {Error} When the OAuth2 client is null
+   */
+  checkClient (): void;
+
+  /**
    * Retrieves the local-initialized Google OAuth2 client
    * @returns {OAuth2Client | null} local Google OAuth2 client
    */
@@ -42,5 +54,11 @@ export interface IGmailOAuthClient {
    * @returns {string | null} Google OAuth2 refresh token
    */
   get refreshToken (): string | null;
+
+  /**
+   * Retrieves the local access token if initialized
+   * @returns {string | null} Google Oauth2 access token
+   */
+  get accessToken (): string | null;
 }
 

--- a/app/src/types/oauth2client.interface.ts
+++ b/app/src/types/oauth2client.interface.ts
@@ -37,6 +37,11 @@ export interface IGmailOAuthClient {
   checkClient (): void;
 
   /**
+   * Sets the value of the local access token
+   */
+  set accessToken (accessToken: GetAccessTokenResponse | null);
+
+  /**
    * Retrieves the local-initialized Google OAuth2 client
    * @returns {OAuth2Client | null} local Google OAuth2 client
    */

--- a/app/src/types/oauth2client.interface.ts
+++ b/app/src/types/oauth2client.interface.ts
@@ -57,8 +57,8 @@ export interface IGmailOAuthClient {
 
   /**
    * Retrieves the local access token if initialized
-   * @returns {string | null} Google Oauth2 access token
+   * @returns {GetAccessTokenResponse | null} Google Oauth2 access token
    */
-  get accessToken (): string | null;
+  get accessToken (): GetAccessTokenResponse | null;
 }
 


### PR DESCRIPTION
- Chore: add an option skip generating a fresh access token when sending email
- Feat: test the `GmailOAuthClient` for generating OAuth2 access tokens
- Chore: test sending an email using a pre-generated OAuth2 access token