### PR TITLE
feat: test initializing the GmailOauthClient from class constructor

### DIFF
--- a/app/src/__tests__/oauth2client.test.ts
+++ b/app/src/__tests__/oauth2client.test.ts
@@ -17,4 +17,19 @@ describe('Google OAuth2 Client class test', () => {
     expect(oauthClient.accessToken).toHaveProperty('token')
     expect(oauthClient.accessToken).toHaveProperty('res')
   })
+
+  it ('should generate an access token using class constructor parameters', async () => {
+    const oauthClient = new GmailOAuthClient({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      redirectURI: process.env.GOOGLE_REDIRECT_URI,
+      refreshToken: process.env.GOOGLE_REFRESH_TOKEN,
+      userEmail: process.env.GOOGLE_USER_EMAIL
+    })
+
+    const token = await oauthClient.getAccessToken()
+
+    expect(token).toHaveProperty('token')
+    expect(token).toHaveProperty('res')
+  })
 })


### PR DESCRIPTION
- Feat: test that initializing GmailOauthClient from class constructor can generate refresh tokens