### PR TITLE
feat: send text email to multiple recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ docker exec -it weaponsforge-sendemail-dev <AVAILABLE_DOCKER_SCRIPT>
 
 **B. Using Only Docker (PowerShell)**
 
-`docker run -it -v ${pwd}/app:/opt/app -v /opt/app/node_modules --rm weaponsforge/sendemail:dev <AVAILABLE_SCRIPT>`
+`docker run -it -v ${pwd}/app:/opt/app -v /opt/app/node_modules --rm weaponsforge/sendemail:dev <AVAILABLE_DOCKER_SCRIPT>`
 
 ### Scripts
 

--- a/app/src/__tests__/send.test.ts
+++ b/app/src/__tests__/send.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 import { send } from '@/lib/index.js'
 import { GmailOAuthClient } from '@/lib/index.js'
 
@@ -6,6 +6,13 @@ const MAX_TIMEOUT = 10000
 const TEST_RECIPIENT = 'tester@gmail.com'
 
 describe('Send email test', () => {
+  const oauthClient = new GmailOAuthClient()
+
+  // Generates an access token to use for the succeeding tests
+  beforeAll(async () => {
+    await oauthClient.generateAccessToken()
+  })
+
   test('Send a text email', async () => {
     // Sending email this way auto-generates a fresh access token
     await expect(send({
@@ -16,9 +23,6 @@ describe('Send email test', () => {
   }, MAX_TIMEOUT)
 
   test('Send a text email using pre-generated OAuth2 access token', async () => {
-    const oauthClient = new GmailOAuthClient()
-    await oauthClient.generateAccessToken()
-
     // Sending email this way does not regenerate an access token
     await expect(
       send(
@@ -27,6 +31,32 @@ describe('Send email test', () => {
           subject: 'Test Simple Message',
           content: 'Henlo!'
         }, oauthClient
+      )
+    ).resolves.toBeUndefined()
+  }, MAX_TIMEOUT)
+
+  test('Send a text email to multiple recipients[]', async () => {
+    await expect(
+      send(
+        {
+          recipients: ['student1@gmail.com', 'student2@gmail.com'],
+          subject: 'Test Multiple Message',
+          content: 'Henlo, hello!'
+        }, oauthClient
+      )
+    ).resolves.toBeUndefined()
+  }, MAX_TIMEOUT)
+
+  test('should send email if there are both recipient and recipients[]', async () => {
+    await expect(
+      send(
+        {
+          recipients: ['person1@gmail.com', 'person2@gmail.com'],
+          recipient: TEST_RECIPIENT,
+          subject: 'Test Multiple Message 2',
+          content: 'Hello there'
+        },
+        oauthClient
       )
     ).resolves.toBeUndefined()
   }, MAX_TIMEOUT)

--- a/app/src/__tests__/sendFormat.test.ts
+++ b/app/src/__tests__/sendFormat.test.ts
@@ -17,7 +17,7 @@ describe('Email format test', () => {
     await oauthClient.generateAccessToken()
   })
 
-  // Testing invalid format emails
+  // Testing email formats
   it('should reject invalid email address format', async () => {
     const invalidEmail = 'tester!#5@.4/'
 
@@ -65,6 +65,7 @@ describe('Email format test', () => {
     ).rejects.toThrow(EmailSchemaMessages.SUBJECT)
   }, MAX_TIMEOUT)
 
+  // Testing long email message content
   it('should reject email message content longer that 1500 characters', async () => {
     const longContent = createLongString(1501)
 
@@ -78,5 +79,18 @@ describe('Email format test', () => {
         oauthClient
       )
     ).rejects.toThrow(EmailSchemaMessages.CONTENT)
+  }, MAX_TIMEOUT)
+
+  // Testing missing recipient or recipients[]
+  it('should reject if recipient or recipients[] is missing', async () => {
+    await expect(
+      send(
+        {
+          subject: TEST_SUBJECT,
+          content: 'Hello there'
+        },
+        oauthClient
+      )
+    ).rejects.toThrow(EmailSchemaMessages.RECIPIENT_REQUIRED)
   }, MAX_TIMEOUT)
 })

--- a/app/src/__tests__/sendFormat.test.ts
+++ b/app/src/__tests__/sendFormat.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 
 import { GmailOAuthClient, send } from '@/lib/index.js'
-import { createLongString } from '@/utils/helpers.js'
+import { createLongString, createRandomTextArray } from '@/utils/helpers.js'
 
 import { EmailSchemaMessages } from '@/types/email.schema.js'
 
@@ -66,7 +66,7 @@ describe('Email format test', () => {
   }, MAX_TIMEOUT)
 
   // Testing long email message content
-  it('should reject email message content longer that 1500 characters', async () => {
+  it('should reject email message content longer than 1500 characters', async () => {
     const longContent = createLongString(1501)
 
     await expect(
@@ -81,8 +81,8 @@ describe('Email format test', () => {
     ).rejects.toThrow(EmailSchemaMessages.CONTENT)
   }, MAX_TIMEOUT)
 
-  // Testing missing recipient or recipients[]
-  it('should reject if recipient or recipients[] is missing', async () => {
+  // Testing missing recipient AND recipients[]
+  it('should reject if recipient or recipients[] are missing', async () => {
     await expect(
       send(
         {
@@ -92,5 +92,37 @@ describe('Email format test', () => {
         oauthClient
       )
     ).rejects.toThrow(EmailSchemaMessages.RECIPIENT_REQUIRED)
+  }, MAX_TIMEOUT)
+
+  // Test maximum 20 recipients
+  it('should reject if recipients[] are more than 20', async () => {
+    const emailList = createRandomTextArray({ length: 21, suffix: '@gmail.com' })
+
+    await expect(
+      send(
+        {
+          recipients: emailList,
+          subject: TEST_SUBJECT,
+          content: 'Hello there'
+        },
+        oauthClient
+      )
+    ).rejects.toThrow(EmailSchemaMessages.RECIPIENT_EMAIL_MAX)
+  }, MAX_TIMEOUT)
+
+  it('should reject if recipient and recipients[] are more than 20', async () => {
+    const emailList = createRandomTextArray({ length: 20, suffix: '@gmail.com' })
+
+    await expect(
+      send(
+        {
+          recipients: emailList,
+          recipient: TEST_RECIPIENT,
+          subject: TEST_SUBJECT,
+          content: 'Hello there'
+        },
+        oauthClient
+      )
+    ).rejects.toThrow(EmailSchemaMessages.RECIPIENT_EMAIL_MAX)
   }, MAX_TIMEOUT)
 })

--- a/app/src/lib/email/send.ts
+++ b/app/src/lib/email/send.ts
@@ -10,6 +10,7 @@ import type { EmailType } from '@/types/email.schema.js'
  */
 export const send = async (params: EmailType, client?: GmailOAuthClient): Promise<void> => {
   const oauthClient = client || new GmailOAuthClient()
+  const { recipient, recipients, subject, content } = params
 
   const handler = new EmailSender({
     host: TRANSPORT_SMTP_HOSTS.GMAIL,
@@ -25,13 +26,14 @@ export const send = async (params: EmailType, client?: GmailOAuthClient): Promis
   }
 
   try {
-    await handler.sendEmail({
-      recipient: params?.recipient,
-      subject: params?.subject,
-      content: params?.content
+    const result = await handler.sendEmail({
+      recipient,
+      recipients,
+      subject,
+      content
     })
 
-    console.log('Email sent to', params?.recipient)
+    console.log('Email sent to', result?.accepted)
   } catch (err: unknown) {
     if (err instanceof Error) {
       throw new Error(err.message)

--- a/app/src/lib/email/sender.ts
+++ b/app/src/lib/email/sender.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 import EmailTransport from '@/lib/email/transport.js'
-import type { IEmailTransportAuth } from '@/types/transport.types.js'
+import type { IEmailTransportAuth, SentMessageInfo } from '@/types/transport.types.js'
 import type { IEmailSender } from '@/types/sender.interface.js'
 import { type EmailType, EmailSchema } from '@/types/email.schema.js'
 import { stringsToArray, zodErrorsToString } from '@/utils/helpers.js'
@@ -16,7 +16,7 @@ class EmailSender extends EmailTransport implements IEmailSender {
     super(params)
   }
 
-  async sendEmail (params: EmailType): Promise<void> {
+  async sendEmail (params: EmailType): Promise<SentMessageInfo> {
     try {
       const transportOptions = this.getTransportOptions()
       const result = EmailSchema.safeParse(params)
@@ -35,7 +35,7 @@ class EmailSender extends EmailTransport implements IEmailSender {
 
       const receivers = stringsToArray(recipient, recipients)
 
-      await this.transporter!.sendMail({
+      return await this.transporter!.sendMail({
         from: transportOptions.auth?.user || process.env.USER_EMAIL,
         to: receivers,
         subject: subject,

--- a/app/src/lib/email/sender.ts
+++ b/app/src/lib/email/sender.ts
@@ -5,7 +5,7 @@ import EmailTransport from '@/lib/email/transport.js'
 import type { IEmailTransportAuth } from '@/types/transport.types.js'
 import type { IEmailSender } from '@/types/sender.interface.js'
 import { type EmailType, EmailSchema } from '@/types/email.schema.js'
-import { zodErrorsToString } from '@/utils/helpers.js'
+import { stringsToArray, zodErrorsToString } from '@/utils/helpers.js'
 
 /**
  * @class EmailSender
@@ -26,11 +26,18 @@ class EmailSender extends EmailTransport implements IEmailSender {
         throw new Error(errors || 'Encountered email parameter validation errors')
       }
 
-      const { recipient, subject, content } = params
+      const {
+        recipient,
+        recipients = [],
+        subject,
+        content
+      } = params
 
-      return await this.transporter!.sendMail({
+      const receivers = stringsToArray(recipient, recipients)
+
+      await this.transporter!.sendMail({
         from: transportOptions.auth?.user || process.env.USER_EMAIL,
-        to: recipient,
+        to: receivers,
         subject: subject,
         text: content
       })

--- a/app/src/lib/email/sender.ts
+++ b/app/src/lib/email/sender.ts
@@ -4,7 +4,7 @@ dotenv.config()
 import EmailTransport from '@/lib/email/transport.js'
 import type { IEmailTransportAuth, SentMessageInfo } from '@/types/transport.types.js'
 import type { IEmailSender } from '@/types/sender.interface.js'
-import { type EmailType, EmailSchema } from '@/types/email.schema.js'
+import { type EmailType, EmailSchema, EmailSchemaMessages } from '@/types/email.schema.js'
 import { stringsToArray, zodErrorsToString } from '@/utils/helpers.js'
 
 /**
@@ -34,6 +34,10 @@ class EmailSender extends EmailTransport implements IEmailSender {
       } = params
 
       const receivers = stringsToArray(recipient, recipients)
+
+      if (receivers.length > 20) {
+        throw new Error(EmailSchemaMessages.RECIPIENT_EMAIL_MAX)
+      }
 
       return await this.transporter!.sendMail({
         from: transportOptions.auth?.user || process.env.USER_EMAIL,

--- a/app/src/types/email.schema.ts
+++ b/app/src/types/email.schema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export enum EmailSchemaMessages {
   RECIPIENT_EMAIL = 'Please enter a valid email address',
   RECIPIENT_EMAIL_LENGTH = 'Email address cannot be longer than 150 characters',
+  RECIPIENT_EMAIL_MAX = 'Maximum of 20 recipients allowed',
   RECIPIENT_REQUIRED = 'Either recipient or recipients must be provided',
   SUBJECT = 'Subject/title cannot be longer than 200 characters',
   CONTENT = 'Email content cannot be longer than 1500 characters'
@@ -30,7 +31,8 @@ export const EmailSchema = z.object({
     z.string()
       .email({ message: EmailSchemaMessages.RECIPIENT_EMAIL })
       .max(150, { message: EmailSchemaMessages.RECIPIENT_EMAIL_LENGTH })
-  ).optional(),
+  ).max(20, { message: EmailSchemaMessages.RECIPIENT_EMAIL_MAX })
+    .optional(),
 
   subject: z.string()
     .max(200, { message: EmailSchemaMessages.SUBJECT }),

--- a/app/src/types/email.schema.ts
+++ b/app/src/types/email.schema.ts
@@ -3,33 +3,52 @@ import { z } from 'zod'
 export enum EmailSchemaMessages {
   RECIPIENT_EMAIL = 'Please enter a valid email address',
   RECIPIENT_EMAIL_LENGTH = 'Email address cannot be longer than 150 characters',
+  RECIPIENT_REQUIRED = 'Either recipient or recipients must be provided',
   SUBJECT = 'Subject/title cannot be longer than 200 characters',
   CONTENT = 'Email content cannot be longer than 1500 characters'
 }
 
+interface IOptionalParams {
+  recipient?: string;
+  recipients?: string[];
+}
+
 /**
  * Schema for email validation within the `EmailTransport.sendEmail()` method
- * @property {string} recipient Email address that will receive an email
- * @property {stirng} subject Email message title (max 100 characters)
- * @property {string} content Email message cotent can can be a simple text or HTML string (max 1500 characters)
+ * @property {string} [recipient] - (Optional) Email address of a recipient that will receive an email. Required if `recipients[]` is undefined.
+ * @property {string[]} [recipients] - (Optional) One (1) or more comma-separated email addresses of of recipients that will receive an email. Required if `recipient` is undefined.
+ * @property {string} subject Email message title (max 100 characters)
+ * @property {string} content Email message content can can be a simple text or HTML string (max 1500 characters)
  */
 export const EmailSchema = z.object({
   recipient: z.string()
     .email({ message: EmailSchemaMessages.RECIPIENT_EMAIL })
-    .max(150, { message: EmailSchemaMessages.RECIPIENT_EMAIL_LENGTH }),
+    .max(150, { message: EmailSchemaMessages.RECIPIENT_EMAIL_LENGTH })
+    .optional(),
+
+  recipients: z.array(
+    z.string()
+      .email({ message: EmailSchemaMessages.RECIPIENT_EMAIL })
+      .max(150, { message: EmailSchemaMessages.RECIPIENT_EMAIL_LENGTH })
+  ).optional(),
 
   subject: z.string()
     .max(200, { message: EmailSchemaMessages.SUBJECT }),
 
   content: z.string()
     .max(1500, { message: EmailSchemaMessages.CONTENT })
-})
+}).refine(
+  (data: IOptionalParams) =>
+    data.recipient !== undefined || (data.recipients !== undefined && data.recipients.length > 0),
+  { message: EmailSchemaMessages.RECIPIENT_REQUIRED }
+)
 
 /**
  * Type representing a validated email object
  * @typedef {Object} EmailSenderType
- * @property {string} recipient - Email address that will receive an email
+ * @property {string} [recipient] - (Optional) Email address of a recipient that will receive an email. Required if `recipients[]` is undefined.
+ * @property {string[]} [recipients] - (Optional) One (1) or more comma-separated email addresses of recipients that will receive an email. Required if `recipient` is undefined.
  * @property {string} subject - Email message title (max 100 characters)
- * @property {string} content - Email message cotent can can be a simple text or HTML string (max 1500 characters)
+ * @property {string} content - Email message content can can be a simple text or HTML string (max 1500 characters)
  */
 export type EmailType = z.infer<typeof EmailSchema>

--- a/app/src/types/transport.types.ts
+++ b/app/src/types/transport.types.ts
@@ -1,5 +1,4 @@
-
-
+export type { SentMessageInfo } from 'nodemailer'
 import SMTPTransport from 'nodemailer/lib/smtp-transport/index.js'
 export { SMTPTransport }
 

--- a/app/src/utils/helpers.ts
+++ b/app/src/utils/helpers.ts
@@ -17,3 +17,14 @@ export const zodErrorsToString = (errors: ZodIssue[]): string => {
 export const createLongString = (length: number = 10): string => {
   return Array.from({ length }).map(() => 'a').join('')
 }
+
+/**
+  * Joins one (1) or more strings into an aray of strings
+  * @param {string} text String of text
+  * @param {string[]} texts Array containing strings of text
+  * @returns {string[]} Array of strings containing the combined parameters
+  */
+export const stringsToArray = (text: string | undefined, texts: string[] = []): string[] => {
+  return [...texts, text]
+    .filter(item => item !== undefined)
+}

--- a/app/src/utils/helpers.ts
+++ b/app/src/utils/helpers.ts
@@ -28,3 +28,29 @@ export const stringsToArray = (text: string | undefined, texts: string[] = []): 
   return [...texts, text]
     .filter(item => item !== undefined)
 }
+
+/**
+ * @interface IRandomTextArrayParams
+ * @param {number} length Number of text elements to create in the array
+ * @param {string} [prefix] (Optional) Short text to append at the beginning of each array element
+ * @param {string} [suffix] (Optional) Short text to append at the end of each array element
+ */
+interface IRandomTextArrayParams {
+  length: number;
+  prefix?: string;
+  suffix?: string;
+}
+
+/**
+ * Creates a variable length Array of strings[] with optional prefix and suffix
+ * @param {IRandomTextArrayParams} params Input properties for creating a random string array
+ * @returns {string[]} Array of random strings
+ */
+export const createRandomTextArray = (params: IRandomTextArrayParams) => {
+  const { length = 1, prefix = '', suffix = '' } = params
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return Array.from({ length }).map(_ =>
+    `${prefix}${Math.random().toString(36).substring(2, 8)}${suffix}`
+  )
+}


### PR DESCRIPTION
- Feat: send a text email to multiple recipients, [#7](https://github.com/weaponsforge/send-email/issues/7) 
- Sample usage 1:<br>
   ```javascript
   import { send } from '@/lib/index.js'

   // Sends email to person1@gmail.com and person2@gmail.com
   await send({
      recipients: ['person1@gmail.com', 'person2@gmail.com'],
      subject: 'Test Simple Message',
      content: 'Henlo!'
   })
   ```

- Sample usage 2:<br>
   ```javascript
   import { send } from '@/lib/index.js'

   // Sends email to person1@gmail.com, person2@gmail.com and someone@gmail.com
   await send({
      recipients: ['person1@gmail.com', 'person2@gmail.com'],
      recipient: 'someone@gmail.com',
      subject: 'Test Simple Message',
      content: 'Henlo!'
   })
   ```