### PR TITLE
feat: validate main class libraries input parameters at runtime

### DIFF
--- a/app/src/__tests__/oauth2client.test.ts
+++ b/app/src/__tests__/oauth2client.test.ts
@@ -1,5 +1,7 @@
+import { z } from 'zod'
 import { describe, expect, it } from 'vitest'
 import { GmailOAuthClient } from '@/lib/index.js'
+import type { GetAccessTokenResponse } from '@/types/oauth2client.types.js'
 
 describe('Google OAuth2 Client class test', () => {
   it('should generate an access token', async () => {
@@ -31,5 +33,28 @@ describe('Google OAuth2 Client class test', () => {
 
     expect(token).toHaveProperty('token')
     expect(token).toHaveProperty('res')
+  })
+
+  it ('should throw an error if incorrect schema is provided', async () => {
+    // See @/types/oauth2client.schema.ts for the correct schema
+    const wrongSchema = z.object({
+      hello: z.string(),
+      world: z.number()
+    })
+
+    expect(() => new GmailOAuthClient(null, wrongSchema)).toThrow()
+  })
+
+  it ('should throw an error when manually setting an incorrect access token', async () => {
+    const oauthClient = new GmailOAuthClient()
+
+    const accessToken = {
+      token: 123, // Expected to be a string
+      res: 'hello' // Expected to be an object
+    } as unknown as GetAccessTokenResponse
+
+    expect(() =>
+      oauthClient.accessToken = accessToken
+    ).toThrow()
   })
 })

--- a/app/src/__tests__/schemavalidator.test.ts
+++ b/app/src/__tests__/schemavalidator.test.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod'
+import { beforeAll, describe, expect, it } from 'vitest'
+import SchemaValidator from '@/lib/validator/schemavalidator.js'
+import type { ZodObjectType } from '@/types/schemavalidator.interface.js'
+
+describe('SchemaValidator class test', () => {
+  let testSchema: SchemaValidator | null = null
+
+  beforeAll(async () => {
+    // Sample zod schema for testing
+    const playerSchema = z.object({
+      name: z.string(),
+      level: z.number(),
+      server: z.string()
+    })
+
+    // Sample schema validator instance
+    testSchema = new SchemaValidator(playerSchema)
+  })
+
+  it('should throw an error if no schema is provided', () => {
+    const typesafeUndefined = undefined as unknown as ZodObjectType
+
+    expect(
+      () => new SchemaValidator(typesafeUndefined)
+    ).toThrow()
+  })
+
+  it ('should validate correct sub-schema when provided with a pick parameter', async () => {
+    const validSubSchema = {
+      server: 'some string',
+      level: 10
+    }
+
+    expect(() =>
+      testSchema!.validate({ data: validSubSchema, pick: true })
+    ).not.toThrow()
+  })
+
+  it ('should throw an error when validating incorrect sub-schema with a pick parameter', async () => {
+    const incorrectSubSchema = {
+      otherKey: 'some string',
+      notAKey: 'some string'
+    }
+
+    expect(() =>
+      testSchema!.validate({ data: incorrectSubSchema, pick: true })
+    ).toThrow()
+  })
+
+  it ('should throw an error when validating incorrect schema data', async () => {
+    const incorrectInputValues = {
+      server: 'some string',
+      level: 'ten'
+    }
+
+    expect(() =>
+      testSchema!.validate({ data: incorrectInputValues, pick: true })
+    ).toThrow()
+  })
+
+  it ('should succeed when validating correct schema data', async () => {
+    const correntInputValues = {
+      server: 'some string',
+      level: 10
+    }
+
+    expect(() =>
+      testSchema!.validate({ data: correntInputValues, pick: true })
+    ).not.toThrow()
+  })
+})

--- a/app/src/__tests__/schemavalidator.test.ts
+++ b/app/src/__tests__/schemavalidator.test.ts
@@ -4,17 +4,17 @@ import SchemaValidator from '@/lib/validator/schemavalidator.js'
 import type { ZodObjectBasicType } from '@/types/schemavalidator.interface.js'
 
 describe('SchemaValidator class test', () => {
+  // Sample schema validator instance
   let testSchema: SchemaValidator | null = null
 
-  beforeAll(async () => {
-    // Sample zod schema for testing
-    const playerSchema = z.object({
-      name: z.string(),
-      level: z.number(),
-      server: z.string()
-    })
+  // Sample zod schema for testing
+  const playerSchema = z.object({
+    name: z.string(),
+    level: z.number(),
+    server: z.string()
+  })
 
-    // Sample schema validator instance
+  beforeAll(async () => {
     testSchema = new SchemaValidator(playerSchema)
   })
 
@@ -77,5 +77,43 @@ describe('SchemaValidator class test', () => {
     expect(() =>
       testSchema!.validate({ data: correntInputValues, pick: true })
     ).not.toThrow()
+  })
+
+  it ('should extract properties from a ZodEffects schema', async () => {
+    const effectsSchema = z.object({
+      id: z.number(),
+      address: z.string(),
+      name: z.string()
+    }).refine((data) =>
+      (data.address !== undefined),
+    { message: 'Address is required' }
+    )
+
+    const testSchema = new SchemaValidator(effectsSchema)
+    const keys = testSchema?.properties
+
+    expect(keys).toBeDefined()
+    expect(keys).toBeInstanceOf(Array)
+  })
+
+  it ('should validate the subset of properties from a ZodEffects schema', async () => {
+    const effectsSchema = z.object({
+      id: z.number(),
+      address: z.string(),
+      name: z.string()
+    }).refine((data) =>
+      (data.id !== undefined),
+    { message: 'ID is required' }
+    )
+
+    const testSchema = new SchemaValidator(effectsSchema)
+    const data = {
+      address: 123,
+      name: 'some string'
+    }
+
+    expect(() =>
+      testSchema.validate({ data, pick: true })
+    ).toThrow()
   })
 })

--- a/app/src/__tests__/schemavalidator.test.ts
+++ b/app/src/__tests__/schemavalidator.test.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { beforeAll, describe, expect, it } from 'vitest'
 import SchemaValidator from '@/lib/validator/schemavalidator.js'
-import type { ZodObjectType } from '@/types/schemavalidator.interface.js'
+import type { ZodObjectBasicType } from '@/types/schemavalidator.interface.js'
 
 describe('SchemaValidator class test', () => {
   let testSchema: SchemaValidator | null = null
@@ -28,7 +28,7 @@ describe('SchemaValidator class test', () => {
   })
 
   it ('should throw an error if no schema is provided', () => {
-    const typesafeUndefined = undefined as unknown as ZodObjectType
+    const typesafeUndefined = undefined as unknown as ZodObjectBasicType
 
     expect(
       () => new SchemaValidator(typesafeUndefined)

--- a/app/src/__tests__/schemavalidator.test.ts
+++ b/app/src/__tests__/schemavalidator.test.ts
@@ -18,7 +18,16 @@ describe('SchemaValidator class test', () => {
     testSchema = new SchemaValidator(playerSchema)
   })
 
-  it('should throw an error if no schema is provided', () => {
+  it ('should list the zod schema keys and properties', () => {
+    const keys = testSchema?.properties
+
+    expect(keys).toBeDefined()
+    expect(keys).toBeInstanceOf(Array)
+    expect(keys?.every(key => typeof key === 'string')).toBe(true)
+    expect(keys).toEqual(['name', 'level', 'server'])
+  })
+
+  it ('should throw an error if no schema is provided', () => {
     const typesafeUndefined = undefined as unknown as ZodObjectType
 
     expect(

--- a/app/src/__tests__/schemavalidator.test.ts
+++ b/app/src/__tests__/schemavalidator.test.ts
@@ -3,22 +3,22 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import SchemaValidator from '@/lib/validator/schemavalidator.js'
 import type { ZodObjectBasicType } from '@/types/schemavalidator.interface.js'
 
-describe('SchemaValidator class test', () => {
+describe('SchemaValidator class test - using zod (ZODOBJECT) schema', () => {
   // Sample schema validator instance
   let testSchema: SchemaValidator | null = null
 
-  // Sample zod schema for testing
-  const playerSchema = z.object({
-    name: z.string(),
-    level: z.number(),
-    server: z.string()
-  })
-
   beforeAll(async () => {
+    // Sample zod ZodObject schema for testing
+    const playerSchema = z.object({
+      name: z.string(),
+      level: z.number(),
+      server: z.string()
+    })
+
     testSchema = new SchemaValidator(playerSchema)
   })
 
-  it ('should list the zod schema keys and properties', () => {
+  it ('should list the ZodObject zod schema keys and properties', () => {
     const keys = testSchema?.properties
 
     expect(keys).toBeDefined()
@@ -78,17 +78,20 @@ describe('SchemaValidator class test', () => {
       testSchema!.validate({ data: correntInputValues, pick: true })
     ).not.toThrow()
   })
+})
+
+describe('SchemaValidator class test - using zod (ZODEFFECTS) schema', () => {
+  // Sample zod ZodEffects schema
+  const effectsSchema = z.object({
+    id: z.number(),
+    address: z.string(),
+    name: z.string()
+  }).refine((data) =>
+    (data.address !== undefined),
+  { message: 'Address is required' }
+  )
 
   it ('should extract properties from a ZodEffects schema', async () => {
-    const effectsSchema = z.object({
-      id: z.number(),
-      address: z.string(),
-      name: z.string()
-    }).refine((data) =>
-      (data.address !== undefined),
-    { message: 'Address is required' }
-    )
-
     const testSchema = new SchemaValidator(effectsSchema)
     const keys = testSchema?.properties
 

--- a/app/src/__tests__/send.test.ts
+++ b/app/src/__tests__/send.test.ts
@@ -47,7 +47,7 @@ describe('Send email test', () => {
     ).resolves.toBeUndefined()
   }, MAX_TIMEOUT)
 
-  test('should send email if there are both recipient and recipients[]', async () => {
+  test('should send email to both recipient and recipients[]', async () => {
     await expect(
       send(
         {

--- a/app/src/__tests__/sendFormat.test.ts
+++ b/app/src/__tests__/sendFormat.test.ts
@@ -82,7 +82,7 @@ describe('Email format test', () => {
   }, MAX_TIMEOUT)
 
   // Testing missing recipient AND recipients[]
-  it('should reject if recipient or recipients[] are missing', async () => {
+  it('should reject if recipient and recipients[] are missing', async () => {
     await expect(
       send(
         {

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -2,5 +2,6 @@ export {
   EmailSender,
   EmailTransport,
   GmailOAuthClient,
+  SchemaValidator,
   send
 } from '@/lib/index.js'

--- a/app/src/lib/email/send.ts
+++ b/app/src/lib/email/send.ts
@@ -17,6 +17,14 @@ export const send = async (params: EmailType, client?: GmailOAuthClient): Promis
     type: TRANSPORT_AUTH_TYPES.OAUTH2
   })
 
+  const properties = handler.schema?.properties
+  const validate = {
+    subject: 'hello'
+  }
+
+  handler.schema?.validate({ data: validate, pick: true })
+  console.log('properties', properties)
+
   try {
     await handler.createTransport3LO(oauthClient)
   } catch (err: unknown) {

--- a/app/src/lib/email/send.ts
+++ b/app/src/lib/email/send.ts
@@ -17,14 +17,6 @@ export const send = async (params: EmailType, client?: GmailOAuthClient): Promis
     type: TRANSPORT_AUTH_TYPES.OAUTH2
   })
 
-  const properties = handler.schema?.properties
-  const validate = {
-    subject: 'hello'
-  }
-
-  handler.schema?.validate({ data: validate, pick: true })
-  console.log('properties', properties)
-
   try {
     await handler.createTransport3LO(oauthClient)
   } catch (err: unknown) {

--- a/app/src/lib/google/oauth2client.ts
+++ b/app/src/lib/google/oauth2client.ts
@@ -2,11 +2,15 @@ import { google } from 'googleapis'
 import dotenv from 'dotenv'
 dotenv.config()
 
+import SchemaValidator from '@/lib/validator/schemavalidator.js'
 import type { IGmailOAuthClient } from '@/types/oauth2client.interface.js'
-import type {
-  GetAccessTokenResponse,
-  IOauthClient,
-  OAuth2Client
+import type { ZodObjectType } from '@/types/schemavalidator.interface.js'
+import { GmailOAuthClientSchema } from '@/types/oauth2client.schema.js'
+
+import {
+  type GetAccessTokenResponse,
+  type IOauthClient,
+  type OAuth2Client
 } from '@/types/oauth2client.types.js'
 
 /**
@@ -26,17 +30,23 @@ class GmailOAuthClient implements IGmailOAuthClient {
   /** Google OAuth2 access token generated using the #refreshToken */
   #accessToken: GetAccessTokenResponse | null = null
 
+  /** Zod schema wrapper methods and functions */
+  #schema: SchemaValidator | null = null
+
   /**
    * @constructor
    * @param {Partial<IOauthClient>} params (Optional) constructor parameters. The corresponding `.env` variables
    * expect to have correct values for the default values.
+   * @param {ZodObjectType} [schema] (Optional) zod Schema. Defaults to the `GmailOAuthClientSchema` if not provided.
    */
-  constructor (params?: Partial<IOauthClient>) {
+  constructor (params?: Partial<IOauthClient> | null, schema?: ZodObjectType) {
     const clientId = params?.clientId || process.env.GOOGLE_CLIENT_ID
     const clientSecret = params?.clientSecret || process.env.GOOGLE_CLIENT_SECRET
     const redirectURI = params?.redirectURI || process.env.GOOGLE_REDIRECT_URI
     const refreshToken = params?.refreshToken || process.env.GOOGLE_REFRESH_TOKEN
     const userEmail = params?.userEmail || process.env.GOOGLE_USER_EMAIL
+
+    this.#schema = new SchemaValidator(schema || GmailOAuthClientSchema)
 
     this.init(<IOauthClient>{
       clientId,
@@ -49,15 +59,9 @@ class GmailOAuthClient implements IGmailOAuthClient {
 
   init (params: IOauthClient): void {
     try {
+      this.#schema?.validate({ data: { ...params } });
+
       const { clientId, clientSecret, redirectURI, refreshToken, userEmail } = params
-
-      if (!userEmail) {
-        throw new Error('Undefined sender email')
-      }
-
-      if (!refreshToken) {
-        throw new Error('Undefined refresh token')
-      }
 
       this.#client = new google.auth.OAuth2(
         clientId,
@@ -93,7 +97,18 @@ class GmailOAuthClient implements IGmailOAuthClient {
   }
 
   set accessToken (accessToken: GetAccessTokenResponse | null) {
+    this.#schema?.checkSchema()
+
+    this.#schema?.validate({
+      data: { accessToken },
+      pick: true
+    })
+
     this.#accessToken = accessToken
+  }
+
+  get schema (): SchemaValidator | null {
+    return this.#schema
   }
 
   get client (): OAuth2Client | null {

--- a/app/src/lib/google/oauth2client.ts
+++ b/app/src/lib/google/oauth2client.ts
@@ -59,7 +59,7 @@ class GmailOAuthClient implements IGmailOAuthClient {
 
   init (params: IOauthClient): void {
     try {
-      this.#schema?.validate({ data: { ...params } });
+      this.#schema?.validate({ data: { ...params } })
 
       const { clientId, clientSecret, redirectURI, refreshToken, userEmail } = params
 

--- a/app/src/lib/google/oauth2client.ts
+++ b/app/src/lib/google/oauth2client.ts
@@ -4,7 +4,7 @@ dotenv.config()
 
 import SchemaValidator from '@/lib/validator/schemavalidator.js'
 import type { IGmailOAuthClient } from '@/types/oauth2client.interface.js'
-import type { ZodObjectType } from '@/types/schemavalidator.interface.js'
+import type { ZodObjectBasicType } from '@/types/schemavalidator.interface.js'
 import { GmailOAuthClientSchema } from '@/types/oauth2client.schema.js'
 
 import {
@@ -37,9 +37,9 @@ class GmailOAuthClient implements IGmailOAuthClient {
    * @constructor
    * @param {Partial<IOauthClient>} params (Optional) constructor parameters. The corresponding `.env` variables
    * expect to have correct values for the default values.
-   * @param {ZodObjectType} [schema] (Optional) zod Schema. Defaults to the `GmailOAuthClientSchema` if not provided.
+   * @param {ZodObjectBasicType} [schema] (Optional) zod Schema. Defaults to the `GmailOAuthClientSchema` if not provided.
    */
-  constructor (params?: Partial<IOauthClient> | null, schema?: ZodObjectType) {
+  constructor (params?: Partial<IOauthClient> | null, schema?: ZodObjectBasicType) {
     const clientId = params?.clientId || process.env.GOOGLE_CLIENT_ID
     const clientSecret = params?.clientSecret || process.env.GOOGLE_CLIENT_SECRET
     const redirectURI = params?.redirectURI || process.env.GOOGLE_REDIRECT_URI

--- a/app/src/lib/index.ts
+++ b/app/src/lib/index.ts
@@ -1,11 +1,13 @@
 import EmailTransport from '@/lib/email/transport.js'
 import EmailSender from '@/lib/email/sender.js'
 import GmailOAuthClient from '@/lib/google/oauth2client.js'
+import SchemaValidator from '@/lib/validator/schemavalidator.js'
 
 export { send } from '@/lib/email/send.js'
 
 export {
   EmailSender,
   EmailTransport,
-  GmailOAuthClient
+  GmailOAuthClient,
+  SchemaValidator
 }

--- a/app/src/lib/validator/schemavalidator.ts
+++ b/app/src/lib/validator/schemavalidator.ts
@@ -94,9 +94,9 @@ class SchemaValidator implements ISchemaValidator {
     }
   }
 
-  get properties (): ZodRawShape {
+  get properties (): string[] {
     this.checkSchema()
-    return this.schema!.shape
+    return Object.keys(this.schema!.shape)
   }
 }
 

--- a/app/src/lib/validator/schemavalidator.ts
+++ b/app/src/lib/validator/schemavalidator.ts
@@ -30,7 +30,7 @@ class SchemaValidator implements ISchemaValidator {
   }
 
   isZodSchema (schema: ZodSchemaType): boolean {
-    if (this.isZodObjectSchema(schema as ZodObjectBasicType)) return true
+    if (this.isZodObjectSchema(<ZodObjectBasicType>schema)) return true
 
     // Check if it's a ZodEffects that wraps a ZodObject; e.g., using z.refine()
     if ('_def' in schema && 'schema' in schema._def) {
@@ -54,12 +54,12 @@ class SchemaValidator implements ISchemaValidator {
       schema._def.typeName === ZodFirstPartyTypeKind.ZodEffects
   }
 
-  getBaseSchema (schema: ZodSchemaType): ZodObjectBasicType | null {
+  getBaseSchema (schema: ZodSchemaType): ZodObjectBasicType {
     if (this.isZodEffectsSchema(schema)) {
-      return (schema._def as ZodEffectsDef).schema as ZodObjectBasicType
+      return (<ZodEffectsDef>schema._def).schema as ZodObjectBasicType
     }
 
-    return null
+    return <ZodObjectBasicType>schema
   }
 
   getSubSchema (data: Record<string, ZodRawShape | unknown>): ZodObjectBasicType | null {
@@ -72,9 +72,9 @@ class SchemaValidator implements ISchemaValidator {
     }
 
     if (this.isZodEffectsSchema(this.schema!)) {
-      schema = this.getBaseSchema(this.schema!) as ZodObjectBasicType
+      schema = <ZodObjectBasicType>this.getBaseSchema(this.schema!)
     } else {
-      schema = this.schema as ZodObjectBasicType
+      schema = <ZodObjectBasicType>this.schema
     }
 
     const originalKeys = Object.keys(schema.shape)
@@ -133,17 +133,17 @@ class SchemaValidator implements ISchemaValidator {
 
   get typeName (): string {
     this.checkSchema()
-    return (this.schema as ZodObjectBasicType)._def.typeName
+    return (<ZodObjectBasicType>this.schema)._def.typeName
   }
 
   get properties (): string[] {
     this.checkSchema()
 
     if (this.isZodEffectsSchema(this.schema!)) {
-      const schema = this.getBaseSchema(this.schema!) as ZodObjectBasicType
+      const schema = <ZodObjectBasicType>this.getBaseSchema(this.schema!)
       return Object.keys(schema.shape)
     } else {
-      return Object.keys((this.schema as ZodObjectBasicType).shape)
+      return Object.keys((<ZodObjectBasicType>this.schema).shape)
     }
   }
 }

--- a/app/src/lib/validator/schemavalidator.ts
+++ b/app/src/lib/validator/schemavalidator.ts
@@ -1,0 +1,103 @@
+import { ZodObject, type ZodIssue, type ZodRawShape } from 'zod'
+
+import type {
+  ISchemaValidator,
+  ISchemaValidateParams,
+  ZodObjectType
+} from '@/types/schemavalidator.interface.js'
+
+/**
+ * @class SchemaValidator
+ * @description Wrapper around a zod schema that returns formatted validation error messages and extracts sub-schemas
+ */
+class SchemaValidator implements ISchemaValidator {
+  schema: ZodObjectType | null = null
+
+  /**
+   * @constructor
+   * @param {ZodObjectType} schema zod schema
+   */
+  constructor (schema: ZodObjectType) {
+    if (!this.isZodSchema(schema)) {
+      throw new Error('Schema is not a zod schema')
+    }
+
+    this.schema = schema
+  }
+
+  isZodSchema (schema: ZodObjectType) {
+    return schema instanceof ZodObject
+  }
+
+  isObject (param: object) {
+    return !Array.isArray(param) && typeof param === 'object'
+  }
+
+  getSubSchema (data: Record<string, ZodRawShape|unknown>): ZodObjectType {
+    this.checkSchema()
+
+    if (!this.isObject(data)) {
+      throw new Error('Input is not an object')
+    }
+
+    const originalKeys = Object.keys(this.schema!.shape)
+    const subKeys = Object.keys(data)
+
+    if (!subKeys.every(key => originalKeys.includes(key))) {
+      throw new Error('Some keys are missing from the original schema')
+    }
+
+    const findKeys = Object
+      .keys(data)
+      .reduce((list, item) => ({ ...list, [item]: true }), {})
+
+    if (Object.keys(subKeys).length > 0) {
+      return this.schema!.pick(findKeys)
+    }
+
+    return this.schema!
+  }
+
+  validate (params: ISchemaValidateParams) {
+    this.checkSchema()
+
+    const { data, errorDelimiter = '\n', pick = false } = params
+    let result
+
+    if (pick) {
+      const subSchema = this.getSubSchema(data)
+      result = subSchema.safeParse(data)
+    } else {
+      result = this.schema!.safeParse(data)
+    }
+
+    if (!result.success) {
+      const errorMessage = this.formatErrors(
+        result?.error?.errors,
+        errorDelimiter
+      )
+
+      throw new Error(errorMessage  || 'Encountered email parameter validation errors')
+    }
+  }
+
+  formatErrors (errors: ZodIssue[], errorDelimiter: string = '\n'): string {
+    return errors.reduce((list, item) => {
+      const message = `${item.message} ${item.path[0]} ${errorDelimiter}`
+      return list + message
+    }, '')
+  }
+
+  checkSchema () {
+    if (!this.schema) {
+      throw new Error('Schema is missing')
+    }
+  }
+
+  get properties (): ZodRawShape {
+    this.checkSchema()
+    return this.schema!.shape
+  }
+}
+
+export default SchemaValidator

--- a/app/src/types/oauth2client.interface.ts
+++ b/app/src/types/oauth2client.interface.ts
@@ -1,3 +1,4 @@
+import SchemaValidator from '@/lib/validator/schemavalidator.js'
 
 import type {
   GetAccessTokenResponse,
@@ -40,6 +41,12 @@ export interface IGmailOAuthClient {
    * Sets the value of the local access token
    */
   set accessToken (accessToken: GetAccessTokenResponse | null);
+
+  /**
+   * Retrieves the local zod schema wrapper
+   * @returns {SchemaValidator | null} Local zod schema validator and wrapper
+   */
+  get schema (): SchemaValidator | null;
 
   /**
    * Retrieves the local-initialized Google OAuth2 client

--- a/app/src/types/oauth2client.schema.ts
+++ b/app/src/types/oauth2client.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const GmailOAuthAccessTokenSchema = z.object({
+  token: z.string(),
+  res: z.record(z.any())
+})
+
+export const GmailOAuthClientSchema = z.object({
+  clientId: z.string().max(200),
+  clientSecret: z.string().max(200),
+  redirectURI: z.string().max(300),
+  refreshToken: z.string().max(500),
+  userEmail: z.string().email().max(150),
+  accessToken: GmailOAuthAccessTokenSchema.optional()
+})

--- a/app/src/types/schemavalidator.interface.ts
+++ b/app/src/types/schemavalidator.interface.ts
@@ -54,7 +54,7 @@ export interface ISchemaValidator {
   validate (params: ISchemaValidateParams): void;
 
   /**
-   * Joins one (1) or more group of zod error messages into a string of text.
+   * Joins one (1) or more group of zod error messages `ZodError[].message` into one (1) string of text.
    * @param {ZodIssue[]} errors One (1) or more zod validation error messages
    * @param {string} [errorDelimiter] (Optional) Character or text to put between one (1) or more zod error messages. Defaults to a newline `"\n"` character.
    */
@@ -71,7 +71,7 @@ export interface ISchemaValidator {
    * Retrieves the object keys of `this.schema`
    * @returns {string[]} Object keys of `this.schema`
    */
-  get properties (): ZodRawShape;
+  get properties (): string[];
 }
 
 /**

--- a/app/src/types/schemavalidator.interface.ts
+++ b/app/src/types/schemavalidator.interface.ts
@@ -1,5 +1,12 @@
-import { ZodObject, type ZodIssue, type ZodRawShape } from 'zod'
-export type ZodObjectType = ZodObject<ZodRawShape>
+import { ZodObject, ZodFirstPartyTypeKind } from 'zod'
+import type { ZodIssue, ZodRawShape, ZodType, ZodEffects } from 'zod'
+
+export type ZodObjectBasicType = ZodObject<ZodRawShape>
+export type ZodObjectEffectsType = ZodType | ZodEffects<any>
+export type ZodObjectInput = ZodObjectBasicType | ZodObjectEffectsType
+
+export type { ZodIssue, ZodRawShape }
+export { ZodObject, ZodFirstPartyTypeKind }
 
 /**
   * Parameter properties of the `ISchemaValidator.validate()` function
@@ -20,14 +27,14 @@ export interface ISchemaValidateParams {
  */
 export interface ISchemaValidator {
   /** zod schema */
-  schema: ZodObjectType | null;
+  schema: ZodObjectBasicType | null;
 
   /**
-   * Checks if an object is a zod schema
-   * @param {ZodObjectType} schema zod schema
+   * Checks if an zod schema is a basic zod schema (`ZodObject`) or an effects schema (`ZodEffects`, e.g., edited with `z.refine()`)
+   * @param {ZodObjectEffectsType} schema zod schema
    * @returns {boolean} Flag that checks if an object is a zod schema
    */
-  isZodSchema (schema: ZodObjectType): boolean;
+  isZodSchema (schema: ZodObjectEffectsType | ZodObjectBasicType): boolean;
 
   /**
    * Checks if an input parameter is an Object
@@ -36,14 +43,27 @@ export interface ISchemaValidator {
    */
   isObject (param: object): boolean;
 
+  /**
+   * Checks if a zod schema is a basic zod schema (`ZodObject`)
+   * @param {ZodObjectBasicType} schema zod schema
+   * @returns {boolean} Flag that checks if an object is a zod schema
+   */
+  isZodObject (schema: ZodObjectBasicType): schema is ZodObjectBasicType;
+
+  /**
+   * Checks if a zod schema is an effects zod schema (`ZodEffects`)
+   * @param {ZodObjectEffectsType} schema zod schema
+   * @returns {boolean} Flag that checks if an object is an effects zod schema
+   */
+  isZodEffects (schema: ZodObjectEffectsType): boolean;
 
   /**
    * Retrieves a subset of the zod `this.schema` using `.pick()`
    * @param {Record<string, any>} data Object that may possibly be a subset of the local zod `this.schema`
-   * @returns {ZodObjectType} Subset of the zod `this.schema`
+   * @returns {ZodObjectBasicType} Subset of the zod `this.schema`
    * @throws {Error} Validation errors. Also throws an error if one (1) or more keys in the `data` parameter are missing in the original `this.schema`
    */
-  getSubSchema (data: Record<string, ZodRawShape>): ZodObjectType;
+  getSubSchema (data: Record<string, ZodRawShape>): ZodObjectBasicType;
 
   /**
    * Validates a set of input parameters with the zod `this.schema`
@@ -68,6 +88,12 @@ export interface ISchemaValidator {
   checkSchema (): void;
 
   /**
+   * Retrieves the type name of the zod schema
+   * @returns {string} Type name of the zod schema
+   */
+  get typeName (): string;
+
+  /**
    * Retrieves the object keys of `this.schema`
    * @returns {string[]} Object keys of `this.schema`
    */
@@ -79,5 +105,5 @@ export interface ISchemaValidator {
  * @interface ISchemaValidatorConstructor
  */
 export interface ISchemaValidatorConstructor {
-  new (schema: ZodObjectType): ISchemaValidator;
+  new (schema: ZodObjectEffectsType): ISchemaValidator;
 }

--- a/app/src/types/schemavalidator.interface.ts
+++ b/app/src/types/schemavalidator.interface.ts
@@ -59,7 +59,7 @@ export interface ISchemaValidator {
   isZodEffectsSchema (schema: ZodSchemaType): boolean;
 
   /**
-   * @description Get the base schema from a `ZodEffects` schema
+   * @description Get the base `ZodObject` schema from a `ZodEffects` schema
    * @param {ZodSchemaType} schema - The `ZodEffects` schema to get the `ZodObject` base schema from
    * @returns {ZodObjectBasicType | null} The base schema or null if it's not a ZodEffects
    */
@@ -97,13 +97,13 @@ export interface ISchemaValidator {
 
   /**
    * Retrieves the type name of the zod schema
-   * @returns {string} Type name of the zod schema
+   * @returns {string} Type name of the zod schema - `ZodObject` or `ZodEffects`
    */
   get typeName (): string;
 
   /**
-   * Retrieves the object keys of `this.schema`
-   * @returns {string[]} Object keys of `this.schema`
+   * Retrieves the object property keys of `this.schema`
+   * @returns {string[]} Object property keys of `this.schema`
    */
   get properties (): string[];
 }

--- a/app/src/types/schemavalidator.interface.ts
+++ b/app/src/types/schemavalidator.interface.ts
@@ -1,0 +1,83 @@
+import { ZodObject, type ZodIssue, type ZodRawShape } from 'zod'
+export type ZodObjectType = ZodObject<ZodRawShape>
+
+/**
+  * Parameter properties of the `ISchemaValidator.validate()` function
+  * @interface ISchemaValidateParams
+  * @param {Record<string, unknown>} data Key-value object pairs to validate with the zod `this.schema`
+  * @param {string} [errorDelimiter] (Optional) Character or text to put between one (1) or more zod error messages. Defaults to a newline `"\n"` character.
+  * @param {boolean} pick (Optional) Flag to validate only a subset of `data`. Defaults to `false`
+  */
+export interface ISchemaValidateParams {
+  data: Record<string, unknown>;
+  errorDelimiter?: string;
+  pick?: boolean;
+}
+
+/**
+ * Public properties and methods of the `SchemaValidator` class.
+ * @interface ISchemaValidator
+ */
+export interface ISchemaValidator {
+  /** zod schema */
+  schema: ZodObjectType | null;
+
+  /**
+   * Checks if an object is a zod schema
+   * @param {ZodObjectType} schema zod schema
+   * @returns {boolean} Flag that checks if an object is a zod schema
+   */
+  isZodSchema (schema: ZodObjectType): boolean;
+
+  /**
+   * Checks if an input parameter is an Object
+   * @param {object} param Object input
+   * @returns {boolean} Flag that checks if the input parameter is an object
+   */
+  isObject (param: object): boolean;
+
+
+  /**
+   * Retrieves a subset of the zod `this.schema` using `.pick()`
+   * @param {Record<string, any>} data Object that may possibly be a subset of the local zod `this.schema`
+   * @returns {ZodObjectType} Subset of the zod `this.schema`
+   * @throws {Error} Validation errors. Also throws an error if one (1) or more keys in the `data` parameter are missing in the original `this.schema`
+   */
+  getSubSchema (data: Record<string, ZodRawShape>): ZodObjectType;
+
+  /**
+   * Validates a set of input parameters with the zod `this.schema`
+   * @param {ISchemaValidateParams} params Validation input parameters
+   * @returns {boolean} Returns `true` if there are no validation errors.
+   * @throws {Error} Combined zod error messages if there are one (1) or more validation errors.
+   */
+  validate (params: ISchemaValidateParams): void;
+
+  /**
+   * Joins one (1) or more group of zod error messages into a string of text.
+   * @param {ZodIssue[]} errors One (1) or more zod validation error messages
+   * @param {string} [errorDelimiter] (Optional) Character or text to put between one (1) or more zod error messages. Defaults to a newline `"\n"` character.
+   */
+  formatErrors (errors: ZodIssue[], errorDelimiter: string): string;
+
+  /**
+   * Checks if the local `this.schema` has been initialized.
+   * @returns {void}
+   * @throws {Error} Throws an error if `this.schema` is null or not yet initialized.
+   */
+  checkSchema (): void;
+
+  /**
+   * Retrieves the object keys of `this.schema`
+   * @returns {string[]} Object keys of `this.schema`
+   */
+  get properties (): ZodRawShape;
+}
+
+/**
+ * Constructor interface of the `SchemaValidator` class.
+ * @interface ISchemaValidatorConstructor
+ */
+export interface ISchemaValidatorConstructor {
+  new (schema: ZodObjectType): ISchemaValidator;
+}

--- a/app/src/types/schemavalidator.interface.ts
+++ b/app/src/types/schemavalidator.interface.ts
@@ -31,7 +31,7 @@ export interface ISchemaValidator {
   schema: ZodSchemaType | null;
 
   /**
-   * Checks if an zod schema is a basic zod schema (`ZodObject`) or an effects schema (`ZodEffects`, e.g., edited with `z.refine()`)
+   * Checks if the input parameter is a zod schema: a basic zod schema (`ZodObject`) or an effects schema (`ZodEffects`, e.g., edited with `z.refine()`)
    * @param {ZodSchemaType} schema zod schema
    * @returns {boolean} Flag that checks if an object is a zod schema
    */
@@ -47,16 +47,16 @@ export interface ISchemaValidator {
   /**
    * Checks if a zod schema is a basic zod schema (`ZodObject`)
    * @param {ZodObjectBasicType} schema zod schema
-   * @returns {boolean} Flag that checks if an object is a zod schema
+   * @returns {boolean} Flag that checks if an object is a ZodObject` zod schema
    */
-  isZodObject (schema: ZodObjectBasicType): schema is ZodObjectBasicType;
+  isZodObjectSchema (schema: ZodObjectBasicType): schema is ZodObjectBasicType;
 
   /**
    * Checks if a zod schema is an effects zod schema (`ZodEffects`)
    * @param {ZodSchemaType} schema zod schema
-   * @returns {boolean} Flag that checks if an object is an effects zod schema
+   * @returns {boolean} Flag that checks if an object is a `ZodEffects` effects zod schema
    */
-  isZodEffects (schema: ZodSchemaType): boolean;
+  isZodEffectsSchema (schema: ZodSchemaType): boolean;
 
   /**
    * @description Get the base schema from a `ZodEffects` schema
@@ -66,7 +66,7 @@ export interface ISchemaValidator {
   getBaseSchema (schema: ZodSchemaType): ZodObjectBasicType | null;
 
   /**
-   * Retrieves only the `ZodObject` base subset of from `this.schema` using `.pick()`. Finds the base `ZodObject` if `this.schema` is a `ZodEffects` schema.
+   * Retrieves only the base `ZodObject` subset from `this.schema` using `.pick()`. Finds the base `ZodObject` if `this.schema` is a `ZodEffects` schema.
    * @param {Record<string, any>} data Object that may possibly be a subset of the local zod `this.schema`
    * @returns {ZodObjectBasicType} `ZodObjectBasicType` subset of the zod `this.schema`
    * @throws {Error} Validation errors. Also throws an error if one (1) or more keys in the `data` parameter are missing in the original `this.schema`

--- a/app/src/types/schemavalidator.interface.ts
+++ b/app/src/types/schemavalidator.interface.ts
@@ -1,12 +1,13 @@
 import { ZodObject, ZodFirstPartyTypeKind } from 'zod'
-import type { ZodIssue, ZodRawShape, ZodType, ZodEffects } from 'zod'
+import type { ZodIssue, ZodRawShape, ZodType, ZodEffects, ZodEffectsDef } from 'zod'
 
 export type ZodObjectBasicType = ZodObject<ZodRawShape>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ZodObjectEffectsType = ZodType | ZodEffects<any>
-export type ZodObjectInput = ZodObjectBasicType | ZodObjectEffectsType
+export type ZodSchemaType = ZodObjectBasicType | ZodObjectEffectsType;
 
 export type { ZodIssue, ZodRawShape }
-export { ZodObject, ZodFirstPartyTypeKind }
+export { type ZodEffectsDef, ZodObject, ZodFirstPartyTypeKind }
 
 /**
   * Parameter properties of the `ISchemaValidator.validate()` function
@@ -27,14 +28,14 @@ export interface ISchemaValidateParams {
  */
 export interface ISchemaValidator {
   /** zod schema */
-  schema: ZodObjectBasicType | null;
+  schema: ZodSchemaType | null;
 
   /**
    * Checks if an zod schema is a basic zod schema (`ZodObject`) or an effects schema (`ZodEffects`, e.g., edited with `z.refine()`)
-   * @param {ZodObjectEffectsType} schema zod schema
+   * @param {ZodSchemaType} schema zod schema
    * @returns {boolean} Flag that checks if an object is a zod schema
    */
-  isZodSchema (schema: ZodObjectEffectsType | ZodObjectBasicType): boolean;
+  isZodSchema (schema: ZodSchemaType): boolean;
 
   /**
    * Checks if an input parameter is an Object
@@ -52,18 +53,25 @@ export interface ISchemaValidator {
 
   /**
    * Checks if a zod schema is an effects zod schema (`ZodEffects`)
-   * @param {ZodObjectEffectsType} schema zod schema
+   * @param {ZodSchemaType} schema zod schema
    * @returns {boolean} Flag that checks if an object is an effects zod schema
    */
-  isZodEffects (schema: ZodObjectEffectsType): boolean;
+  isZodEffects (schema: ZodSchemaType): boolean;
 
   /**
-   * Retrieves a subset of the zod `this.schema` using `.pick()`
+   * @description Get the base schema from a `ZodEffects` schema
+   * @param {ZodSchemaType} schema - The `ZodEffects` schema to get the `ZodObject` base schema from
+   * @returns {ZodObjectBasicType | null} The base schema or null if it's not a ZodEffects
+   */
+  getBaseSchema (schema: ZodSchemaType): ZodObjectBasicType | null;
+
+  /**
+   * Retrieves only the `ZodObject` base subset of from `this.schema` using `.pick()`. Finds the base `ZodObject` if `this.schema` is a `ZodEffects` schema.
    * @param {Record<string, any>} data Object that may possibly be a subset of the local zod `this.schema`
-   * @returns {ZodObjectBasicType} Subset of the zod `this.schema`
+   * @returns {ZodObjectBasicType} `ZodObjectBasicType` subset of the zod `this.schema`
    * @throws {Error} Validation errors. Also throws an error if one (1) or more keys in the `data` parameter are missing in the original `this.schema`
    */
-  getSubSchema (data: Record<string, ZodRawShape>): ZodObjectBasicType;
+  getSubSchema (data: Record<string, ZodRawShape | unknown>): ZodObjectBasicType | null;
 
   /**
    * Validates a set of input parameters with the zod `this.schema`

--- a/app/src/types/sender.interface.ts
+++ b/app/src/types/sender.interface.ts
@@ -1,4 +1,5 @@
 import type { EmailType } from '@/types/email.schema.js'
+import SchemaValidator from '@/lib/validator/schemavalidator.js'
 
 export interface IEmailSender {
   /**
@@ -8,4 +9,10 @@ export interface IEmailSender {
    * @throws {ZodIssue[]} Input parameter validation error/s
    */
   sendEmail (params: EmailType): Promise<void>;
+
+  /**
+   * Retrieves the email sender's local zod schema wrapper
+   * @returns {SchemaValidator | null} zod schema validator for the email sender
+   */
+  get schema (): SchemaValidator | null;
 }

--- a/app/src/utils/helpers.ts
+++ b/app/src/utils/helpers.ts
@@ -1,14 +1,3 @@
-import type { ZodIssue } from 'zod'
-
-/**
- * Converts one or more arrays of `ZodError[].message` into one (1) string
- * @param {ZodError[]} errors List of error data from zod `parse` or `safeParse` validation
- * @returns {string} Zod error message(s) in string format
- */
-export const zodErrorsToString = (errors: ZodIssue[]): string => {
-  return errors.reduce((list, item) => list + item.message + '\n', '')
-}
-
 /**
  * Creates a sequence of N-length `"a"` characters
  * @param {number} length String length


### PR DESCRIPTION
- Feat: create a validation class for handling zod `ZodObject` or `ZodEffects` type schemas
- Feat: validate the GmailOAuthClient class properties at runtime and create tests, [#30](https://github.com/weaponsforge/send-email/issues/30)
- Feat: validate the EmailSener class properties at runtime and create tests
