### PR TITLE
v1.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,9 @@ on:
     types: [published]
 
 jobs:
-  lint-transpile-app:
+  lint-test-app:
     name: Lint and Test App
+    if: github.event.release.target_commitish == 'main'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -41,7 +42,7 @@ jobs:
       - name: Transpile
         run: |
           cd app
-          npm run transpile
+          npm run transpile:noemit
 
       - name: Test
         run: |
@@ -62,10 +63,84 @@ jobs:
           files: app/html/junit.xml
           check_name: "Test Results"
 
+  build-sea:
+    name: Build and Package App
+    if: github.event.release.target_commitish == 'main'
+    needs: [lint-test-app]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Use NodeJS v24.11.0
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.11.0
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('app/package-lock.json') }}
+          restore-keys: npm-
+
+      - name: Install Dependencies
+        run: |
+          cd app
+          npm ci
+
+      - name: Package and archive the executable files
+        run: |
+          cd app
+          chmod u+x ./scripts/build-sea-win.sh
+          ./scripts/build-sea-win.sh
+          cd build
+          ls -l -a
+          mkdir -p dist
+          mv sendemail.exe dist/
+
+      - name: Archive Development Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: app/build/dist/
+          retention-days: 1
+
+  release-binaries:
+    name: Release Built Binary
+    if: github.event.release.target_commitish == 'main'
+    needs: [lint-test-app, build-sea]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Prepare App
+        run: |
+          mv sendemail.exe sendemail_${{github.ref_name}}.exe
+          tar cvfz sendemail_${{github.ref_name}}.tar.gz sendemail_${{github.ref_name}}.exe
+          ls -l -a
+
+      - name: Attach Artifact to Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            sendemail_${{github.ref_name}}.tar.gz
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   docker-build-push:
     name: Build and Push Docker Image
     if: github.event.release.target_commitish == 'main' && vars.DOCKERHUB_USERNAME != ''
-    needs: [lint-transpile-app]
+    needs: [lint-test-app, build-sea]
     runs-on: ubuntu-latest
     env:
       REGISTRY: docker.io
@@ -127,7 +202,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy Scan Results to GitHub Security Tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 NPM scripts, library and CLI for sending text and HTML emails using Gmail SMTP with Google OAuth2.
 
+> [!TIP]
+> - **Pre-compiled windows binaries**<br>
+>    Pre-compiled [windows binaries](#️-building-the-windows-executable-file) are available for download in the latest [Releases](https://github.com/weaponsforge/send-email/releases) download page.
+>
+> - **Docker image**<br>
+>   A Docker image is available at https://hub.docker.com/r/weaponsforge/sendemail
+
 ### Table of Contents
 
 - [Requirements](#-requirements)
@@ -482,6 +489,8 @@ docker exec -it weaponsforge-sendemail-dev sh ./scripts/build-sea-win.sh
    ```bash
    sendemail text -s "You are Invited" -c "Birthday party" -r a@gmail.com,b@gmail.com
    ```
+
+<br>
 
 ## 🚀 Usage with GitHub Actions
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "send-email",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "send-email",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "send-email",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Sends emails using Gmail SMTP with username/pw or Google OAuth2",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
### Update

- feat: publish sea windows cli binary on releases page, [PR #45](https://github.com/weaponsforge/send-email/pull/45)

### Usage

1. Download a send-email Windows binary from the Releases page, eg., `send-email_v1.21.tar.gz` from https://github.com/weaponsforge/send-email/releases/tag/v1.2.1

2. Extract the contents of `send-email_v1.21.tar.gz` to `send-email_v1.21.exe`

3. Refer to [**Available Scripts - C. CLI**](https://github.com/weaponsforge/send-email#-available-scripts) for CLI argument syntax. When running the executable directly, invoke it without npm (no "--" needed), for example:

   ```sh
   sendemail_v1.2.1 text -s "You are Invited" -c "Birthday party" -r a@gmail.com,b@gmail.com
   ```