### PR TITLE
v1.2.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
             CACHEBUST=${{ github.run_id }}
 
       - name: Scan Image for Vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: 'sarif'

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weaponsforge/sendemail",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weaponsforge/sendemail",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaponsforge/sendemail",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Sends emails using Gmail SMTP with username/pw or Google OAuth2",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Fix: use the fixed and stable trivy-action v0.35.0 as check for deployment to Docker Hub

## Related Issues
- Fixes https://github.com/aquasecurity/trivy-action/issues/541

## Type of Change
- [x] Other (please describe): CI/CD

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/weaponsforge/send-email/blob/dev/CONTRIBUTING.md)
- [x] I have linked relevant issues
- [x] I have rotated related secret keys and tokens 

## Additional Context

- [Trivy Compromised a Second Time - Malicious v0.69.4 Release](https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release)

## Screenshots
<img width="868" height="562" alt="trivy-fail" src="https://github.com/user-attachments/assets/5dc7cd20-bde7-494b-84a8-6629a675b18b" />
